### PR TITLE
Add tokenize method to LlamaClient and MLXClient

### DIFF
--- a/Sources/LocalLLMClientLlama/LlamaClient.swift
+++ b/Sources/LocalLLMClientLlama/LlamaClient.swift
@@ -1,5 +1,12 @@
 import Foundation
 import LocalLLMClient
+#if BUILD_DOCC
+@preconcurrency @_implementationOnly import llama
+#elseif canImport(llama)
+@preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
+#endif
 
 /// A client for interacting with the Llama models.
 ///
@@ -66,6 +73,14 @@ public final class LlamaClient: LLMClient {
         }
 
         return Generator(context: context)
+    }
+    
+    /// Tokenizes the given text and returns the number of tokens.
+    /// - Parameter text: The text to tokenize.
+    /// - Returns: The number of tokens in the text.
+    public func tokenize(_ text: String) -> Int {
+        let tokens = [llama_token](text, addBos: false, special: true, vocab: context.vocab)
+        return tokens.count
     }
 }
 

--- a/Sources/LocalLLMClientMLX/MLXClient.swift
+++ b/Sources/LocalLLMClientMLX/MLXClient.swift
@@ -82,6 +82,17 @@ public final actor MLXClient: LLMClient {
             }
         }
     }
+    
+    /// Tokenizes the given text and returns the number of tokens.
+    /// - Parameter text: The text to tokenize.
+    /// - Returns: The number of tokens in the text.
+    public func tokenize(_ text: String) async -> Int {
+        let modelContainer = context.modelContainer
+        return await modelContainer.perform { context in
+            let tokens = context.tokenizer.encode(text: text)
+            return tokens.count
+        }
+    }
 }
 
 private extension [LLMAttachment] {


### PR DESCRIPTION
This pull request introduces enhancements to the Llama and MLX clients in the `LocalLLMClient` package, focusing on improving modularity and adding a new tokenization feature. The most important changes include conditional imports for better build configuration and the addition of a `tokenize` method to both `LlamaClient` and `MLXClient`.

### Build Configuration Improvements:
* [`Sources/LocalLLMClientLlama/LlamaClient.swift`](diffhunk://#diff-c93dfe440f416f8434dfda48b39fa7a6a095d1392a1b11a8affe82eae724a964R3-R9): Added conditional imports to manage dependencies based on build configurations (`BUILD_DOCC`, `canImport(llama)`, or fallback to `LocalLLMClientLlamaC`). This ensures compatibility across different environments.

### New Tokenization Feature:
* [`Sources/LocalLLMClientLlama/LlamaClient.swift`](diffhunk://#diff-c93dfe440f416f8434dfda48b39fa7a6a095d1392a1b11a8affe82eae724a964R77-R84): Introduced a `tokenize` method to calculate the number of tokens in a given text using the Llama model's tokenizer.
* [`Sources/LocalLLMClientMLX/MLXClient.swift`](diffhunk://#diff-5e83e6fdc64cc30dc1b8bad942e2fb3423eb8e7d9a4cd1fa06d57801c0bef688R85-R95): Added an asynchronous `tokenize` method to compute token counts using the MLX model's tokenizer, leveraging the `context.modelContainer`.