### PR TITLE
Improve file download checks and code clarity

### DIFF
--- a/Sources/LocalLLMClientUtility/Downloader.swift
+++ b/Sources/LocalLLMClientUtility/Downloader.swift
@@ -33,7 +33,9 @@ final class CentralizedProgressTracker: Sendable {
     
     func updateFileProgress(identifier: String, downloadedSize: Int64) {
         let didUpdate = fileProgress.withLock { progress in
-            guard var fileProgress = progress[identifier] else { return false }
+            guard var fileProgress = progress[identifier] else { 
+                return false 
+            }
             fileProgress.downloadedSize = downloadedSize
             progress[identifier] = fileProgress
             return true
@@ -46,7 +48,9 @@ final class CentralizedProgressTracker: Sendable {
     
     func markFileCompleted(identifier: String, finalSize: Int64? = nil) {
         fileProgress.withLock { progress in
-            guard var fileProgress = progress[identifier] else { return }
+            guard var fileProgress = progress[identifier] else { 
+                return 
+            }
             if let finalSize = finalSize {
                 fileProgress.downloadedSize = finalSize
             } else {

--- a/Sources/LocalLLMClientUtility/FileDownloader.swift
+++ b/Sources/LocalLLMClientUtility/FileDownloader.swift
@@ -70,6 +70,11 @@ public struct FileDownloader: FileDownloadable {
                 .compactMap { $0 as? URL } ?? []
             let filesOnDisk = Dictionary(uniqueKeysWithValues: fileURLs.map { ($0.lastPathComponent, $0) })
 
+            // Empty metadata means no files should exist, so not downloaded
+            guard !meta.files.isEmpty else {
+                return false
+            }
+            
             return meta.files.allSatisfy { file in
                 guard let fileURL = filesOnDisk[file.name] else {
                     return false
@@ -171,7 +176,9 @@ public struct FileDownloader: FileDownloadable {
     public func download(onProgress: @Sendable @escaping (Double) async -> Void = { _ in }) async throws {
         let destination = source.destination(for: rootDestination)
         
-        guard !source.isDownloaded(for: destination) else {
+        let alreadyDownloaded = source.isDownloaded(for: destination)
+        
+        guard !alreadyDownloaded else {
             await onProgress(1.0)
             return
         }


### PR DESCRIPTION
This pull request includes minor improvements to the `LocalLLMClientUtility` module, focusing on code readability and logic adjustments in the `Downloader.swift` and `FileDownloader.swift` files. The changes enhance maintainability and ensure clearer handling of edge cases.

### Code readability improvements:

* [`Sources/LocalLLMClientUtility/Downloader.swift`](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L36-R38): Reformatted `guard` statements in the `updateFileProgress` and `markFileCompleted` methods of the `CentralizedProgressTracker` class to improve readability by placing the `else` clause on a new line. [[1]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L36-R38) [[2]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L49-R53)

### Logic adjustments:

* [`Sources/LocalLLMClientUtility/FileDownloader.swift`](diffhunk://#diff-b6bed6785ce2fed4a5e19ea669e0fc51aef56b1c436e04cf90bacc36b78d17ceR73-R77): Added a check in the `isDownloaded` method to return `false` if metadata is empty, ensuring that no files are considered downloaded when metadata is missing.
* [`Sources/LocalLLMClientUtility/FileDownloader.swift`](diffhunk://#diff-b6bed6785ce2fed4a5e19ea669e0fc51aef56b1c436e04cf90bacc36b78d17ceL174-R181): Refactored the `download` method to store the result of the `isDownloaded` check in a variable (`alreadyDownloaded`) for clarity and potential reuse.